### PR TITLE
feat: add StreamCodec for GenericOrder and GenericStack serialization

### DIFF
--- a/abstractions/src/main/java/ru/zznty/create_factory_abstractions/api/generic/stack/GenericStack.java
+++ b/abstractions/src/main/java/ru/zznty/create_factory_abstractions/api/generic/stack/GenericStack.java
@@ -1,6 +1,8 @@
 package ru.zznty.create_factory_abstractions.api.generic.stack;
 
 import com.simibubi.create.content.logistics.factoryBoard.FactoryPanelBehaviour;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.ItemStack;
 import ru.zznty.create_factory_abstractions.api.generic.GenericFilterProvider;
 import ru.zznty.create_factory_abstractions.api.generic.key.GenericKey;
@@ -35,4 +37,17 @@ public record GenericStack(GenericKey key, int amount) {
         GenericFilterProvider filterProvider = (GenericFilterProvider) behaviour;
         return filterProvider.filter();
     }
+
+    public static void writeToStream(RegistryFriendlyByteBuf buffer, GenericStack stack) {
+        ru.zznty.create_factory_abstractions.generic.stack.GenericStackSerializer.write(stack, buffer);
+    }
+
+    public static GenericStack readFromStream(RegistryFriendlyByteBuf buffer) {
+        return ru.zznty.create_factory_abstractions.generic.stack.GenericStackSerializer.read(buffer);
+    }
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, GenericStack> STREAM_CODEC = StreamCodec.of(
+            GenericStack::writeToStream,
+            GenericStack::readFromStream
+    );
 }

--- a/abstractions/src/main/java/ru/zznty/create_factory_abstractions/generic/support/GenericOrder.java
+++ b/abstractions/src/main/java/ru/zznty/create_factory_abstractions/generic/support/GenericOrder.java
@@ -11,6 +11,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 import ru.zznty.create_factory_abstractions.CreateFactoryAbstractions;
@@ -164,4 +165,13 @@ public record GenericOrder(List<GenericStack> stacks, List<PackageOrderWithCraft
             return null;
         return GenericOrder.read(levelRegistryAccess, frag.getCompound("OrderContext"));
     }
+
+    public static void writeToStream(RegistryFriendlyByteBuf buffer, GenericOrder order) {
+        order.write(buffer);
+    }
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, GenericOrder> STREAM_CODEC = StreamCodec.of(
+            GenericOrder::writeToStream,
+            GenericOrder::read
+    );
 }


### PR DESCRIPTION
This is needed for sending the GenericOrder & GenericStack with Packet

See:
https://github.com/timplay33/Create-Mobile-Packages/blob/176abcb96b0e1c97a6a73698e96741981035c8d1/src/main/java/de/theidler/create_mobile_packages/items/portable_stock_ticker/SendPackage.java#L21C58-L21C59

https://github.com/timplay33/Create-Mobile-Packages/blob/176abcb96b0e1c97a6a73698e96741981035c8d1/src/main/java/de/theidler/create_mobile_packages/items/portable_stock_ticker/GenericStackListPacket.java#L18