### PR TITLE
Fix Fluid-only orders get voided when repackaging instead of combining jars, Fix for #159, and #156

### DIFF
--- a/forge/src/main/java/ru/zznty/create_factory_logistics/logistics/repackager/CompositeRepackagerHelper.java
+++ b/forge/src/main/java/ru/zznty/create_factory_logistics/logistics/repackager/CompositeRepackagerHelper.java
@@ -10,30 +10,45 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
 import ru.zznty.create_factory_logistics.logistics.composite.CompositePackageItem;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CompositeRepackagerHelper extends PackageRepackageHelper {
     @Override
     public List<BigItemStack> repack(int orderId, RandomSource r) {
         List<BigItemStack> exportingPackages = super.repack(orderId, r);
-        if (exportingPackages.isEmpty()) return exportingPackages;
 
-        UnmodifiableIterator<List<ItemStack>> partitioned = Iterators.partition(collectedPackages.get(orderId)
-                        .stream().filter(box -> box.getItem().getClass() != PackageItem.class).iterator(),
-                Iterate.horizontalDirections.length);
+        List<ItemStack> nonPackageItems = collectedPackages.get(orderId)
+                .stream()
+                .filter(box -> box.getItem().getClass() != PackageItem.class)
+                .collect(Collectors.toList());
+
+        // if its a single jar, dont make a composite package and instead a normal jar
+        if (exportingPackages.isEmpty() && nonPackageItems.size() == 1) {
+            List<BigItemStack> result = new ArrayList<>();
+            result.add(new BigItemStack(nonPackageItems.get(0)));
+            return result;
+        }
+
+        UnmodifiableIterator<List<ItemStack>> partitioned = Iterators.partition(
+                nonPackageItems.iterator(),
+                Iterate.horizontalDirections.length
+        );
 
         int i = 0;
         while (partitioned.hasNext() && i < exportingPackages.size()) {
-            exportingPackages.set(i, new BigItemStack(CompositePackageItem.of(exportingPackages.get(i).stack, partitioned.next().stream().toList())));
+            List<ItemStack> additional = partitioned.next();
+            ItemStack base = exportingPackages.get(i).stack;
+            exportingPackages.set(i, new BigItemStack(CompositePackageItem.of(base, additional)));
             i++;
         }
 
-        if (partitioned.hasNext())
-            partitioned.forEachRemaining(list -> {
-                for (ItemStack box : list) {
-                    exportingPackages.add(new BigItemStack(box));
-                }
-            });
+        while (partitioned.hasNext()) {
+            List<ItemStack> fluidGroup = partitioned.next();
+            ItemStack dummy = ItemStack.EMPTY;
+            exportingPackages.add(new BigItemStack(CompositePackageItem.of(dummy, fluidGroup)));
+        }
 
         return exportingPackages;
     }


### PR DESCRIPTION
Details:
- if its a single fluid jar getting repackaged, outpack back the jar no voiding
- if multiple fluid jars getting repackaged, create a composite package with no items

<img width="227" height="178" alt="image" src="https://github.com/user-attachments/assets/069e2b84-d9b0-417f-9c67-2092a5642d4f" />
