### PR TITLE
Fix for server crash (issue #127)

### DIFF
--- a/forge/src/main/java/ru/zznty/create_factory_logistics/FactoryIcons.java
+++ b/forge/src/main/java/ru/zznty/create_factory_logistics/FactoryIcons.java
@@ -1,20 +1,33 @@
 package ru.zznty.create_factory_logistics;
 
 import com.simibubi.create.foundation.gui.AllIcons;
+
+import net.neoforged.fml.loading.FMLEnvironment;
 import ru.zznty.create_factory_logistics.render.IconAtlasIndexHolder;
 
 public class FactoryIcons {
     public static final AllIcons
-            I_NETWORK_LINK_STORED = next(),
-            I_NETWORK_LINK_PROMISED = next(),
-            I_NETWORK_LINK_ALL = next();
+            I_NETWORK_LINK_STORED,
+            I_NETWORK_LINK_PROMISED,
+            I_NETWORK_LINK_ALL;
 
     private static int x, y;
 
+    static {
+        if (FMLEnvironment.dist.isClient()) {
+            I_NETWORK_LINK_STORED = next();
+            I_NETWORK_LINK_PROMISED = next();
+            I_NETWORK_LINK_ALL = next();
+        } else {
+            I_NETWORK_LINK_STORED = null;
+            I_NETWORK_LINK_PROMISED = null;
+            I_NETWORK_LINK_ALL = null;
+        }
+    }
+
     private static AllIcons next() {
         AllIcons icon = new AllIcons(x++, y);
-        IconAtlasIndexHolder holder = (IconAtlasIndexHolder) icon;
-        holder.setIconAtlasIndex(1);
+        ((IconAtlasIndexHolder) icon).setIconAtlasIndex(1);
         return icon;
     }
 }


### PR DESCRIPTION
### Summary:
Fixes a server crash caused by a ClassCastException in the static initialization of FactoryIcons. The crash occurred because the code attempted to cast AllIcons to IconAtlasIndexHolder on the server, where the mixin is not applied.

### Details:
- The static initialization of custom icons in FactoryIcons is now guarded to only run on the client (FMLEnvironment.dist.isClient()).
- On the server, the icon fields are set to null, preventing the invalid cast and crash.
- No changes were needed to the mixin or interface; they remain client-only as intended.

### Tested:
- The mod will no longer crash the server when player interacts with the Network Link.
- Client icons still render as expected.
