### PR TITLE
Fix client lags when crafting from large stacks in stock keeper

### DIFF
--- a/abstractions/src/main/java/ru/zznty/create_factory_abstractions/api/generic/crafting/RecipeRequestHelper.java
+++ b/abstractions/src/main/java/ru/zznty/create_factory_abstractions/api/generic/crafting/RecipeRequestHelper.java
@@ -249,7 +249,7 @@ public final class RecipeRequestHelper {
                 List<GenericStack> resolvedList = resolvedIngredients.get(ingredient);
                 for (int j = 0; j < list.size(); j++) {
                     GenericStack stack = list.get(j);
-                    if (stack.amount() <= 0)
+                    if (stack.amount() < ingredient.amount())
                         continue;
 
                     list.set(j, stack.withAmount(stack.amount() - ingredient.amount()));
@@ -257,7 +257,7 @@ public final class RecipeRequestHelper {
 
                     for (int k = 0; k < resolvedList.size(); k++) {
                         GenericStack resolvedItemStack = resolvedList.get(k);
-                        if (resolvedItemStack == stack) {
+                        if (resolvedItemStack.key() == stack.key()) {
                             resolvedList.set(k, resolvedItemStack.withAmount(
                                     resolvedItemStack.amount() + ingredient.amount()));
                             continue Ingredients;


### PR DESCRIPTION
When using a stock keeper to issue a crafting order, the algorithm to calculate crafting ingredients tends to lag the client when working with large amount of items. After debugging it, it turns out that `RecipeRequestHelper.resolveIngredientAmounts` had a bug causing it to split the source stacks into individual stacks of 1 item each, while the same time having an `O(n^2)` complexity over the list of resolved ingredients of given type. During my testing attempting to craft while having 20K planks in the system causes the client to freeze for about 10 seconds. This happens when adding the crafting recipe for the first time, or when scrolling on the requested item in the stock keeper GUI.

Here's a proof of buggy behavior from the debugger session:
<img width="1274" height="943" alt="image" src="https://github.com/user-attachments/assets/bbc03f5e-31dd-42fc-a846-12f0c16aff59" />

The fix changes how the item stacks are consolidated by comparing only the generic stack keys (which are also stacks), which prevents the list from growing and properly utilizes the stack amount value in resolved list. Now adding a crafting recipe or scrolling over one does not have any noticeable impact on client performance.