### PR TITLE
Changing fluid amounts with scroll now defaults to 1B

### DIFF
--- a/forge/src/main/java/ru/zznty/create_factory_logistics/logistics/panel/FactoryFluidPanelBehaviour.java
+++ b/forge/src/main/java/ru/zznty/create_factory_logistics/logistics/panel/FactoryFluidPanelBehaviour.java
@@ -121,24 +121,30 @@ public class FactoryFluidPanelBehaviour extends FactoryPanelBehaviour implements
         if (level >= BigItemStack.INF)
             return CreateLang.text("\u221e");
 
-        if (!round || level < 1000 || level % 1000 != 0) {
-            if (level % 1000 == 0)
-                return CreateLang.number((float) level / 1000).add(CreateLang.translate("generic.unit.buckets"));
+        if (level >= 1_000_000){ // If more than 1k buckets, show as thousands
+            return CreateLang.number((float) level / 1_000_000)
+                    .add(CreateLang.text("k"))
+                    .add(CreateLang.translate("generic.unit.buckets"));
+        }
 
+        if (level % 1000 == 0){ //If perfect bucket, show as buckets
+            return CreateLang.number((float) level / 1000).add(CreateLang.translate("generic.unit.buckets"));
+        }
+
+        if (level < 2_000){ // Less than 2B, always show mb
             return CreateLang.number(level).add(CreateLang.translate("generic.unit.millibuckets"));
         }
 
-        // 1000 buckets
-        if (level < 1_000_000) {
+        if (round){ // If more than 2B and rounding, show as buckets
             float d = (float) level / 1000;
             if (d >= 100)
-                d = Math.round(d);
+                d = Math.round(d); //stop showing decimals if more than 100B
             return CreateLang.number(d).add(CreateLang.translate("generic.unit.buckets"));
         }
 
-        return CreateLang.number((float) level / 1_000_000)
-                .add(CreateLang.text("k"))
-                .add(CreateLang.translate("generic.unit.buckets"));
+        // More than 2B and no rounding, show mb
+        return CreateLang.number(level).add(CreateLang.translate("generic.unit.millibuckets"));
+
     }
 
     @Override

--- a/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/panel/FactoryPanelScreenMixin.java
+++ b/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/panel/FactoryPanelScreenMixin.java
@@ -18,6 +18,7 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraftforge.fluids.FluidStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
@@ -27,6 +28,7 @@ import ru.zznty.create_factory_abstractions.api.generic.stack.GenericStack;
 import ru.zznty.create_factory_abstractions.generic.impl.GenericContentExtender;
 import ru.zznty.create_factory_abstractions.generic.support.BigGenericStack;
 import ru.zznty.create_factory_logistics.FactoryBlocks;
+import ru.zznty.create_factory_logistics.logistics.generic.FluidKey;
 import ru.zznty.create_factory_logistics.logistics.jar.JarPackageItem;
 import ru.zznty.create_factory_logistics.logistics.panel.FactoryFluidPanelBehaviour;
 
@@ -336,6 +338,17 @@ public abstract class FactoryPanelScreenMixin extends AbstractSimiScreen {
         int maxStackSize = GenericContentExtender.registrationOf(stack.get().key()).clientProvider().guiHandler()
                 .maxStackSize(stack.get().key());
 
+        if (stack.get().key() instanceof FluidKey){
+            var scrollAmount = (value - stack.asStack().count) / (hasShiftDown() ? 10 : 1);
+            var multiplier = 1000;
+
+            if (hasShiftDown() && hasControlDown()) {multiplier = 1;}
+            else if (hasControlDown()) {multiplier = 10;}
+            else if (hasShiftDown()) {multiplier = 100;}
+
+            value = stack.asStack().count + scrollAmount * multiplier;
+        }
+
         if (maxStackSize < 0)
             return Math.max(1, value);
 
@@ -355,6 +368,17 @@ public abstract class FactoryPanelScreenMixin extends AbstractSimiScreen {
 
         int maxStackSize = GenericContentExtender.registrationOf(stack.get().key()).clientProvider().guiHandler()
                 .maxStackSize(stack.get().key());
+
+        if (stack.get().key() instanceof FluidKey){
+            var scrollAmount = (value - stack.asStack().count) / (hasShiftDown() ? 10 : 1); //Get back scroll amount
+
+            var multiplier = 1000; //If no keys pressed
+            if (hasShiftDown() && hasControlDown()) {multiplier = 1;}
+            else if (hasControlDown()) {multiplier = 10;}
+            else if (hasShiftDown()) {multiplier = 100;}
+
+            value = stack.asStack().count + scrollAmount * multiplier;
+        }
 
         if (maxStackSize < 0)
             return Math.max(1, value);

--- a/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/panel/FactoryPanelScreenMixin.java
+++ b/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/panel/FactoryPanelScreenMixin.java
@@ -332,21 +332,19 @@ public abstract class FactoryPanelScreenMixin extends AbstractSimiScreen {
             )
     )
     private int scrollInputClampRemoval(int value, int min, int max, Operation<Integer> original,
-                                        @Local BigItemStack itemStack) {
+                                        @Local BigItemStack itemStack, @Local(ordinal = 2, argsOnly = true) double pDelta) {
         BigGenericStack stack = BigGenericStack.of(itemStack);
 
         int maxStackSize = GenericContentExtender.registrationOf(stack.get().key()).clientProvider().guiHandler()
                 .maxStackSize(stack.get().key());
 
         if (stack.get().key() instanceof FluidKey){
-            var scrollAmount = (value - stack.asStack().count) / (hasShiftDown() ? 10 : 1);
-            var multiplier = 1000;
-
+            var multiplier = 1000; //If no keys pressed
             if (hasShiftDown() && hasControlDown()) {multiplier = 1;}
             else if (hasControlDown()) {multiplier = 10;}
             else if (hasShiftDown()) {multiplier = 100;}
 
-            value = stack.asStack().count + scrollAmount * multiplier;
+            value = (int) (stack.asStack().count + Math.signum(pDelta) * multiplier);
         }
 
         if (maxStackSize < 0)
@@ -363,21 +361,19 @@ public abstract class FactoryPanelScreenMixin extends AbstractSimiScreen {
                     ordinal = 1
             )
     )
-    private int scrollOutputClampRemoval(int value, int min, int max, Operation<Integer> original) {
+    private int scrollOutputClampRemoval(int value, int min, int max, Operation<Integer> original, @Local(ordinal = 2, argsOnly = true) double pDelta) {
         BigGenericStack stack = BigGenericStack.of(outputConfig);
 
         int maxStackSize = GenericContentExtender.registrationOf(stack.get().key()).clientProvider().guiHandler()
                 .maxStackSize(stack.get().key());
 
         if (stack.get().key() instanceof FluidKey){
-            var scrollAmount = (value - stack.asStack().count) / (hasShiftDown() ? 10 : 1); //Get back scroll amount
-
             var multiplier = 1000; //If no keys pressed
             if (hasShiftDown() && hasControlDown()) {multiplier = 1;}
             else if (hasControlDown()) {multiplier = 10;}
             else if (hasShiftDown()) {multiplier = 100;}
 
-            value = stack.asStack().count + scrollAmount * multiplier;
+            value = (int) (stack.asStack().count + Math.signum(pDelta) * multiplier);
         }
 
         if (maxStackSize < 0)

--- a/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/redstoneRequester/RedstoneRequesterScreenMixin.java
+++ b/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/redstoneRequester/RedstoneRequesterScreenMixin.java
@@ -29,11 +29,13 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.SlotItemHandler;
 import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import ru.zznty.create_factory_abstractions.api.generic.stack.GenericStack;
@@ -44,6 +46,7 @@ import ru.zznty.create_factory_abstractions.generic.support.GenericGhostMenu;
 import ru.zznty.create_factory_abstractions.generic.support.GenericRedstoneRequester;
 import ru.zznty.create_factory_abstractions.generic.support.GenericRedstoneRequesterConfigurationPacket;
 import ru.zznty.create_factory_logistics.logistics.generic.FluidGenericStack;
+import ru.zznty.create_factory_logistics.logistics.generic.FluidKey;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -161,6 +164,28 @@ public abstract class RedstoneRequesterScreenMixin extends AbstractSimiContainer
     private boolean isIngredientEmptyMouseHandler(boolean original,
                                                   @Share("genericStackLocalRef") LocalRef<GenericStack> genericStackLocalRef) {
         return genericStackLocalRef.get().isEmpty();
+    }
+
+    @ModifyArg(
+            method = "mouseScrolled",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/util/Mth;clamp(III)I"
+            ),
+            index = 0
+    )
+    private int transferNum(int transfer,@Local(ordinal = 2) int i, @Share("genericStackLocalRef") LocalRef<GenericStack> genericStackLocalRef){
+        if (genericStackLocalRef.get().key() instanceof FluidKey){
+            var scrollAmount = (transfer-amounts.get(i))/(hasShiftDown() ? 10 : 1); //get back scroll amount
+            var multiplier = 1000; //If no keys are pressed
+
+            if (hasShiftDown() && hasControlDown()) {multiplier = 1;}
+            else if (hasControlDown()) {multiplier = 10;}
+            else if (hasShiftDown()) {multiplier = 100;}
+
+            transfer = amounts.get(i) + scrollAmount * multiplier;
+        }
+        return transfer;
     }
 
     @ModifyConstant(

--- a/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/redstoneRequester/RedstoneRequesterScreenMixin.java
+++ b/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/redstoneRequester/RedstoneRequesterScreenMixin.java
@@ -174,16 +174,14 @@ public abstract class RedstoneRequesterScreenMixin extends AbstractSimiContainer
             ),
             index = 0
     )
-    private int transferNum(int transfer,@Local(ordinal = 2) int i, @Share("genericStackLocalRef") LocalRef<GenericStack> genericStackLocalRef){
+    private int transferNum(int transfer, @Local(ordinal = 2) int i, @Local(ordinal = 2, argsOnly = true) double pDelta , @Share("genericStackLocalRef") LocalRef<GenericStack> genericStackLocalRef){
         if (genericStackLocalRef.get().key() instanceof FluidKey){
-            var scrollAmount = (transfer-amounts.get(i))/(hasShiftDown() ? 10 : 1); //get back scroll amount
             var multiplier = 1000; //If no keys are pressed
-
             if (hasShiftDown() && hasControlDown()) {multiplier = 1;}
             else if (hasControlDown()) {multiplier = 10;}
             else if (hasShiftDown()) {multiplier = 100;}
 
-            transfer = amounts.get(i) + scrollAmount * multiplier;
+            transfer = (int) (amounts.get(i) + Math.signum(pDelta) * multiplier);
         }
         return transfer;
     }

--- a/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/stockKeeper/StockKeeperRequestScreenMixin.java
+++ b/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/stockKeeper/StockKeeperRequestScreenMixin.java
@@ -25,6 +25,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import ru.zznty.create_factory_abstractions.api.generic.crafting.OrderProvider;
 import ru.zznty.create_factory_abstractions.api.generic.crafting.RecipeRequestHelper;
@@ -36,6 +37,7 @@ import ru.zznty.create_factory_abstractions.generic.impl.GenericContentExtender;
 import ru.zznty.create_factory_abstractions.generic.support.BigGenericStack;
 import ru.zznty.create_factory_abstractions.generic.support.CraftableGenericStack;
 import ru.zznty.create_factory_abstractions.generic.support.GenericInventorySummary;
+import ru.zznty.create_factory_logistics.logistics.generic.FluidKey;
 import ru.zznty.create_factory_logistics.logistics.ingredient.ClickableIngredientProvider;
 import ru.zznty.create_factory_logistics.mixin.accessor.CategoryEntryAccessor;
 import ru.zznty.create_factory_logistics.mixin.accessor.StockTickerBlockEntityAccessor;
@@ -165,6 +167,21 @@ public abstract class StockKeeperRequestScreenMixin extends AbstractSimiContaine
         BigGenericStack genericStack = BigGenericStack.of(BigGenericStack.of(entry).get().withAmount(1));
         genericStack.setAmount(0);
         return genericStack.asStack();
+    }
+
+    @ModifyArg(
+            method = "mouseScrolled",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/util/Mth;ceil(D)I"
+            )
+    )
+    private double transferNum(double transfer, @Local BigItemStack entry){
+        if (BigGenericStack.of(entry).get().key() instanceof FluidKey){
+            var scrollAmount = transfer/(hasControlDown() ? 10 : 1); //Get back scroll amount
+            transfer = scrollAmount * (hasControlDown()? 10 : 1000);
+        }
+        return transfer;
     }
 
     @Redirect(

--- a/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/stockKeeper/StockKeeperRequestScreenMixin.java
+++ b/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/stockKeeper/StockKeeperRequestScreenMixin.java
@@ -17,6 +17,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.renderer.Rect2i;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -176,10 +177,9 @@ public abstract class StockKeeperRequestScreenMixin extends AbstractSimiContaine
                     target = "Lnet/minecraft/util/Mth;ceil(D)I"
             )
     )
-    private double transferNum(double transfer, @Local BigItemStack entry){
+    private double transferNum(double transfer, @Local BigItemStack entry, @Local(ordinal = 2, argsOnly = true) double delta){
         if (BigGenericStack.of(entry).get().key() instanceof FluidKey){
-            var scrollAmount = transfer/(hasControlDown() ? 10 : 1); //Get back scroll amount
-            transfer = scrollAmount * (hasControlDown()? 10 : 1000);
+            transfer = Mth.ceil(Math.abs(delta)) * (hasControlDown()? 10 : 1000);
         }
         return transfer;
     }


### PR DESCRIPTION
Changes: Added and changed a few mixins

I also tried adding tooltips to explain the fluid amounts but couldn't figure it out.
If you think tooltips are needed I can look further into it

## New Fluid Amounts
### In a stock ticker:
Shift + Click = 1B
Ctrl + Click = 10mb
Click = 1mb

Shift + Scroll = 1B
Shift + Ctrl + Scroll = 10mb
[You need to hold shift in a stock ticker or else the whole menu scrolls]

### In a Gauge or Redstone Requester:
Scroll = 1B
Shift + Scroll = 100mb
Ctrl + Scroll = 10mb
Shift + Ctrl + Scroll = 1mb

