### PR TITLE
fix: removing `setSatisfied` so redstone links work again

### DIFF
--- a/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/panel/FactoryPanelRequestMixin.java
+++ b/forge/src/main/java/ru/zznty/create_factory_logistics/mixin/logistics/panel/FactoryPanelRequestMixin.java
@@ -3,7 +3,6 @@ package ru.zznty.create_factory_logistics.mixin.logistics.panel;
 import com.google.common.collect.Multimap;
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.sugar.Local;
 import com.simibubi.create.Create;
 import com.simibubi.create.content.logistics.factoryBoard.*;
 import com.simibubi.create.content.logistics.packager.IdentifiedInventory;
@@ -25,8 +24,6 @@ import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import ru.zznty.create_factory_abstractions.api.generic.capability.PackagerAttachedHandler;
 import ru.zznty.create_factory_abstractions.api.generic.stack.GenericStack;
 import ru.zznty.create_factory_abstractions.generic.support.*;
@@ -286,12 +283,4 @@ public abstract class FactoryPanelRequestMixin extends FilteringBehaviour implem
         panelBE.advancements.awardPlayer(AllAdvancements.FACTORY_GAUGE);
     }
 
-    @ModifyVariable(
-            method = "tickStorageMonitor",
-            at = @At("STORE"),
-            ordinal = 0
-    )
-    private boolean setSatisfied(boolean value, @Local(ordinal = 1) int promised) {
-        return value && promised == 0;
-    }
 }


### PR DESCRIPTION
Fixes https://github.com/zznty/CreateFactoryLogistics/issues/222

<img width="932" height="595" alt="image" src="https://github.com/user-attachments/assets/ee608f4f-6102-4254-9b59-9d12ba588679" />

I'm pretty sure it doesn't break anything else after minimal regression testing. 